### PR TITLE
Fix course handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ Aplicación web educativa en español para aprender programación de forma autó
 
 ## Características
 
-- Rutas de aprendizaje por lenguaje (Python, JavaScript, Java, C++).
+ - Rutas de aprendizaje por lenguaje (Python, JavaScript, Java, C++). Las rutas que no están disponibles muestran un aviso.
 - Ejemplos ejecutables y teoría concisa.
 - Quizzes y seguimiento de progreso local.
 - Modo oscuro automático y funcionamiento offline (Service Worker).
-- Consola integrada para mostrar resultados de código.
+ - Consola integrada para mostrar resultados de código (solo JavaScript).
 
 ## Uso
 

--- a/src/scripts.js
+++ b/src/scripts.js
@@ -50,6 +50,7 @@ themeBtn.addEventListener('click', () => {
 // Renderizado de contenido
 const content = document.getElementById('content');
 const output = document.getElementById('output');
+let currentLang = null;
 
 document.querySelectorAll('nav a').forEach(link => {
     link.addEventListener('click', (e) => {
@@ -61,7 +62,13 @@ document.querySelectorAll('nav a').forEach(link => {
 
 function showCourse(lang) {
     const course = courses[lang];
-    if (!course) return;
+    if (!course) {
+        content.innerHTML = '<p>Ruta en desarrollo</p>';
+        output.textContent = '';
+        currentLang = null;
+        return;
+    }
+    currentLang = lang;
     let html = `<h2>${course.titulo}</h2>`;
     course.modulos.forEach((mod, idx) => {
         html += `
@@ -77,6 +84,10 @@ function showCourse(lang) {
 }
 
 function runCode(code) {
+    if (currentLang !== 'javascript') {
+        showMessage('La ejecución de código solo está disponible para JavaScript.');
+        return;
+    }
     try {
         const result = eval(code);
         showMessage(result !== undefined ? result : 'Código ejecutado');


### PR DESCRIPTION
## Summary
- show a message if a chosen course is not yet available
- limit code execution to JavaScript examples
- document that only JS execution is supported and note unavailable routes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68442c46d9cc832c9fef59acb6bfe23d